### PR TITLE
Support mqtt on localhost / internal mqtt

### DIFF
--- a/models/engines/Rhasspy.py
+++ b/models/engines/Rhasspy.py
@@ -42,11 +42,19 @@ class Rhasspy:
 				conf = json.load(confFile)
 
 				try:
-					configs['mqttServer'] = conf['mqtt']['host']
-					configs['mqttPort'] = conf['mqtt'].get('port', 1883)
-					configs['mqttUsername'] = conf['mqtt'].get('username', '')
-					configs['mqttPassword'] = conf['mqtt'].get('password', '')
-					configs['mqttTLSCAFile'] = ''
+					if conf['mqtt']['enabled']:
+						configs['mqttServer'] = conf['mqtt'].get('host','localhost')
+						configs['mqttPort'] = conf['mqtt'].get('port', 1883)
+						configs['mqttUsername'] = conf['mqtt'].get('username', '')
+						configs['mqttPassword'] = conf['mqtt'].get('password', '')
+						configs['mqttTLSCAFile'] = ''
+					else:
+						configs['mqttServer'] = 'localhost'
+						configs['mqttPort'] = 12183
+						configs['mqttUsername'] = ''
+						configs['mqttPassword'] = ''
+						configs['mqttTLSCAFile'] = ''
+					
 					siteId = conf['mqtt'].get('site_id', 'default')
 					configs['deviceName'] = siteId.split(',')[0]
 


### PR DESCRIPTION
(1) It seems, that (at least) rhasspy 2.5 does not set host in the mqtt section, if the host is localhost -> therefore using default localhost
(2) If mqtt.enabled is false, use the default values from the documentation (possibly wrong?)